### PR TITLE
FIX: changing resource import

### DIFF
--- a/module.xml
+++ b/module.xml
@@ -21,7 +21,10 @@
       <SourcesRoot>src</SourcesRoot>
       <Resource Name="dc.irisbi.PKG"/>
       <Resource Name="dc.irisbi.covid19D.GBL" />
-      <Resource Name="*.DFI" />
+      <!-- <Resource Name="*.DFI" /> -->
+      <Resource FilenameExtension="dfi" Name="Covid19-Countries.dashboard.DFI" />
+      <Resource Name="Covid19-ConfirmedByCountries.pivot.DFI" />
+      <Resource Name="Covid19-ConfirmedByProvince.pivot.DFI" />
       <Invokes>
         <Invoke Class="%DeepSee.Utils" Method="%BuildCube">
           <Arg>CovidCube</Arg>


### PR DESCRIPTION
This changes are applied for security and stability 
According to this comment *.DFI are now deprecated

https://github.com/intersystems/ipm/issues/473#issuecomment-2085123053